### PR TITLE
Priors

### DIFF
--- a/src/bearing.jl
+++ b/src/bearing.jl
@@ -105,16 +105,18 @@ function BoundaryBasis(boundarytype::BC;
     return BoundaryBasis{BC,BD}(boundarytype, basis)
 end
 
-struct BearingSimulation{BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, T}
+# something is going wrong in BearingSimulation, feel like it might be down to declaring BD <: BoundaryData... I think it maybe doesn't expect boundarydata1(/2) to be dependant on the type Float64... how to remedy ? 
+
+struct BearingSimulation{BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, BC <: BoundaryCondition, T}
     ω::T
     basis_order::Int
     bearing::RollerBearing{T}
     boundarydata1::BoundaryData{BC1,T}
     boundarydata2::BoundaryData{BC2,T}
-    boundarybasis::BoundaryBasis{BC1,T}
+    boundarybasis::BoundaryBasis{BC,BoundaryData}
     tol::T
 
-    function BearingSimulation(ω::T, bearing::RollerBearing{T}, boundarydata1::BoundaryData{BC1,T}, boundarydata2::BoundaryData{BC2,T}; tol::T = eps(T)^(1/2), basis_order::Int = -1, boundarybasis::BoundaryBasis{BC1,T} = BoundaryBasis(boundarydata1.boundarytype)) where {T, BC1 <: BoundaryCondition, BC2 <: BoundaryCondition}
+    function BearingSimulation(ω::T, bearing::RollerBearing{T}, boundarydata1::BoundaryData{BC1,T}, boundarydata2::BoundaryData{BC2,T}; tol::T = eps(T)^(1/2), basis_order::Int = -1, boundarybasis::BoundaryBasis{BC,BoundaryData} = BoundaryBasis(boundarydata1.boundarytype)) where {BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, BC <: BoundaryCondition, T}
 
         if size(boundarydata1.fourier_modes,1) != size(boundarydata2.fourier_modes,1)
             @error "number of fourier_modes in boundarydata1 and boundarydata2 needs to be the same"
@@ -162,6 +164,6 @@ struct BearingSimulation{BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, T}
             )
         end
 
-        new{BC1,BC2,T}(ω, basis_order, bearing, boundarydata1, boundarydata2, boundarybasis, tol)
+        new{BC1,BC2,T,BC}(ω, basis_order, bearing, boundarydata1, boundarydata2, tol, boundarybasis)
     end
 end

--- a/src/bearing.jl
+++ b/src/bearing.jl
@@ -76,13 +76,6 @@ struct BoundaryData{BC <: BoundaryCondition, T}
     fourier_modes::Matrix{Complex{T}}
 end
 
-struct BoundaryBasis{BC <: BoundaryCondition, T}
-    boundarytype::BC
-    θs::Vector{T}
-    fields::Matrix{Complex{T}}
-    fourier_modes::Matrix{Complex{T}}
-end
-
 
 function BoundaryData(boundarytype::BC;
         θs::AbstractVector{T} = Float64[],
@@ -101,6 +94,29 @@ function BoundaryData(boundarytype::BC;
     return BoundaryData{BC,T}(boundarytype,θs,fields,fourier_modes)
 end
 
+struct BoundaryBasis{BC <: BoundaryCondition, T}
+    boundarytype::BC
+    θs::Vector{T}
+    basis::Matrix{Complex{T}}
+    fourier_modes::Matrix{Complex{T}}
+end
+
+function BoundaryBasis(boundarytype::BC;
+    θs::AbstractVector{T} = Float64[],
+    basis::Matrix = reshape(Complex{Float64}[],0,1),
+    fourier_modes::Matrix = reshape(Complex{Float64}[],0,1)
+) where {BC <: BoundaryCondition, T}
+
+if !isempty(fourier_modes) && size(fourier_modes,2) != 2
+    @error "the fourier_modes should have only two columns"
+end
+
+if !isempty(basis) && size(basis,1) != length(θs)
+    @error "the basis should be evaluated at each θ"
+end
+
+return BoundaryBasis{BC,T}(boundarytype,θs,basis,fourier_modes)
+end
 
 struct BearingSimulation{BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, T}
     ω::T

--- a/src/bearing.jl
+++ b/src/bearing.jl
@@ -6,17 +6,20 @@ struct RollerBearing{T}
     outer_radius::T
     "vector of angles delimiting gaps in the outer radius"
     outer_gaps::Vector{T}
+    "vector of angles delimiting gaps in the outer radius"
+    number_of_rollers::Int
 end
 
 function RollerBearing(; medium::Elasticity{2},
         inner_radius::T = 0.0, outer_radius::T = 0.0,
         inner_gaps::Vector{T} = typeof(inner_radius)[],
-        outer_gaps::Vector{T} = typeof(outer_radius)[]
+        outer_gaps::Vector{T} = typeof(outer_radius)[],
+        number_of_rollers = -1
     ) where T<:Number
     if isodd(length(inner_gaps)) && isodd(length(outer_gaps))
         @error "both inner_gaps and outer_gaps need to be an even number of angles"
     end
-    RollerBearing{T}(medium, inner_radius, inner_gaps, outer_radius, outer_gaps)
+    RollerBearing{T}(medium, inner_radius, inner_gaps, outer_radius, outer_gaps, number_of_rollers)
 end
 
 

--- a/src/bearing.jl
+++ b/src/bearing.jl
@@ -101,6 +101,7 @@ struct BoundaryBasis{BC <: BoundaryCondition, T}
     fourier_modes::Matrix{Complex{T}}
 end
 
+
 function BoundaryBasis(boundarytype::BC;
     θs::AbstractVector{T} = Float64[],
     basis::Matrix = reshape(Complex{Float64}[],0,1),

--- a/src/bearing.jl
+++ b/src/bearing.jl
@@ -102,6 +102,11 @@ end
 function BoundaryBasis(boundarytype::BC;
     basis::Vector{BD} = BoundaryData{BC,ComplexF64}[]
 ) where {BC <: BoundaryCondition,BD<:BoundaryData}
+    for b in basis
+        if b.boundarytype != boundarytype
+            @error "Elements of basis must have the same boundary type as boundarybasis."
+        end
+    end
     return BoundaryBasis{BC,BD}(boundarytype, basis)
 end
 

--- a/src/bearing.jl
+++ b/src/bearing.jl
@@ -102,7 +102,6 @@ end
 function BoundaryBasis(boundarytype::BC;
     basis::Vector{BD} = BoundaryData{BC,ComplexF64}[]
 ) where {BC <: BoundaryCondition,BD<:BoundaryData}
-
     return BoundaryBasis{BC,BD}(boundarytype, basis)
 end
 
@@ -163,6 +162,19 @@ struct BearingSimulation{BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, BB 
             )
         end
 
+        #need fourier_modes from boundarybasis
+        for i in 1:length(boundarybasis.basis)
+            if isempty(boundarybasis.basis[i].fourier_modes)
+                println("The Fourier Modes in boundarybasis.basis[", i,"] are empty and will be calculated from the fields provided" )
+                modes = fields_to_fouriermodes(boundarybasis.basis[i].θs, boundarybasis.basis[i].fields, basis_order)
+                    boundarybasis.basis[i] = BoundaryData(boundarybasis.basis[i].boundarytype;
+                        fourier_modes = modes,
+                        fields = boundarybasis.basis[i].fields,
+                        θs = boundarybasis.basis[i].θs
+                    )
+            end
+        end
+        
         new{BC1,BC2,BB,T}(ω, bearing, boundarydata1, boundarydata2, tol, basis_order, boundarybasis)
     end
 end

--- a/src/bearing.jl
+++ b/src/bearing.jl
@@ -107,13 +107,13 @@ function BoundaryBasis(boundarytype::BC;
     fourier_modes::Matrix = reshape(Complex{Float64}[],0,1)
 ) where {BC <: BoundaryCondition, T}
 
-if !isempty(fourier_modes) && size(fourier_modes,2) != 2
-    @error "the fourier_modes should have only two columns"
-end
+    if !isempty(fourier_modes) && size(fourier_modes,2) != 2
+        @error "the fourier_modes should have only two columns"
+    end
 
-if !isempty(basis) && size(basis,1) != length(θs)
-    @error "the basis should be evaluated at each θ"
-end
+    if !isempty(basis) && size(basis,1) != length(θs)
+        @error "the basis should be evaluated at each θ"
+    end
 
 return BoundaryBasis{BC,T}(boundarytype,θs,basis,fourier_modes)
 end

--- a/src/bearing.jl
+++ b/src/bearing.jl
@@ -76,6 +76,14 @@ struct BoundaryData{BC <: BoundaryCondition, T}
     fourier_modes::Matrix{Complex{T}}
 end
 
+struct BoundaryBasis{BC <: BoundaryCondition, T}
+    boundarytype::BC
+    θs::Vector{T}
+    fields::Matrix{Complex{T}}
+    fourier_modes::Matrix{Complex{T}}
+end
+
+
 function BoundaryData(boundarytype::BC;
         θs::AbstractVector{T} = Float64[],
         fields::Matrix = reshape(Complex{Float64}[],0,1),

--- a/src/bearing.jl
+++ b/src/bearing.jl
@@ -100,23 +100,22 @@ struct BoundaryBasis{BC <: BoundaryCondition,BD<:BoundaryData}
 end
 
 function BoundaryBasis(boundarytype::BC;
-    basis::Vector{BD} = BoundaryData[]
+    basis::Vector{BD} = BoundaryData{BC,ComplexF64}[]
 ) where {BC <: BoundaryCondition,BD<:BoundaryData}
+
     return BoundaryBasis{BC,BD}(boundarytype, basis)
 end
 
-# something is going wrong in BearingSimulation, feel like it might be down to declaring BD <: BoundaryData... I think it maybe doesn't expect boundarydata1(/2) to be dependant on the type Float64... how to remedy ? 
-
-struct BearingSimulation{BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, BC <: BoundaryCondition, T}
+struct BearingSimulation{BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, BB <: BoundaryBasis, T}
     ω::T
-    basis_order::Int
     bearing::RollerBearing{T}
     boundarydata1::BoundaryData{BC1,T}
     boundarydata2::BoundaryData{BC2,T}
-    boundarybasis::BoundaryBasis{BC,BoundaryData}
     tol::T
+    basis_order::Int
+    boundarybasis::BB
 
-    function BearingSimulation(ω::T, bearing::RollerBearing{T}, boundarydata1::BoundaryData{BC1,T}, boundarydata2::BoundaryData{BC2,T}; tol::T = eps(T)^(1/2), basis_order::Int = -1, boundarybasis::BoundaryBasis{BC,BoundaryData} = BoundaryBasis(boundarydata1.boundarytype)) where {BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, BC <: BoundaryCondition, T}
+    function BearingSimulation(ω::T, bearing::RollerBearing{T}, boundarydata1::BoundaryData{BC1,T}, boundarydata2::BoundaryData{BC2,T}; tol::T = eps(T)^(1/2), basis_order::Int = -1, boundarybasis::BB = BoundaryBasis(boundarydata1.boundarytype)) where {BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, BB <:BoundaryBasis, T}
 
         if size(boundarydata1.fourier_modes,1) != size(boundarydata2.fourier_modes,1)
             @error "number of fourier_modes in boundarydata1 and boundarydata2 needs to be the same"
@@ -164,6 +163,6 @@ struct BearingSimulation{BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, BC 
             )
         end
 
-        new{BC1,BC2,T,BC}(ω, basis_order, bearing, boundarydata1, boundarydata2, tol, boundarybasis)
+        new{BC1,BC2,BB,T}(ω, bearing, boundarydata1, boundarydata2, tol, basis_order, boundarybasis)
     end
 end

--- a/src/bearing.jl
+++ b/src/bearing.jl
@@ -125,9 +125,10 @@ struct BearingSimulation{BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, T}
     bearing::RollerBearing{T}
     boundarydata1::BoundaryData{BC1,T}
     boundarydata2::BoundaryData{BC2,T}
+    boundarybasis::BoundaryBasis{BC1,T}
     tol::T
 
-    function BearingSimulation(ω::T, bearing::RollerBearing{T}, boundarydata1::BoundaryData{BC1,T}, boundarydata2::BoundaryData{BC2,T}; tol::T = eps(T)^(1/2), basis_order::Int = -1) where {T, BC1 <: BoundaryCondition, BC2 <: BoundaryCondition}
+    function BearingSimulation(ω::T, bearing::RollerBearing{T}, boundarydata1::BoundaryData{BC1,T}, boundarydata2::BoundaryData{BC2,T},boundarybasis::BoundaryBasis{BC1,T}=BoundaryBasis{typeof(boundarydata1.boundarytype),typeof(bearing.medium.cp)}[]; tol::T = eps(T)^(1/2), basis_order::Int = -1) where {T, BC1 <: BoundaryCondition, BC2 <: BoundaryCondition}
 
         if size(boundarydata1.fourier_modes,1) != size(boundarydata2.fourier_modes,1)
             @error "number of fourier_modes in boundarydata1 and boundarydata2 needs to be the same"
@@ -175,6 +176,6 @@ struct BearingSimulation{BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, T}
             )
         end
 
-        new{BC1,BC2,T}(ω, basis_order, bearing, boundarydata1, boundarydata2, tol)
+        new{BC1,BC2,T}(ω, basis_order, bearing, boundarydata1, boundarydata2, boundarybasis, tol)
     end
 end

--- a/src/bearing.jl
+++ b/src/bearing.jl
@@ -94,29 +94,15 @@ function BoundaryData(boundarytype::BC;
     return BoundaryData{BC,T}(boundarytype,θs,fields,fourier_modes)
 end
 
-struct BoundaryBasis{BC <: BoundaryCondition, T}
+struct BoundaryBasis{BC <: BoundaryCondition,BD<:BoundaryData}
     boundarytype::BC
-    θs::Vector{T}
-    basis::Matrix{Complex{T}}
-    fourier_modes::Matrix{Complex{T}}
+    basis::Vector{BD}
 end
 
-
 function BoundaryBasis(boundarytype::BC;
-    θs::AbstractVector{T} = Float64[],
-    basis::Matrix = reshape(Complex{Float64}[],0,1),
-    fourier_modes::Matrix = reshape(Complex{Float64}[],0,1)
-) where {BC <: BoundaryCondition, T}
-
-    if !isempty(fourier_modes) && size(fourier_modes,2) != 2
-        @error "the fourier_modes should have only two columns"
-    end
-
-    if !isempty(basis) && size(basis,1) != length(θs)
-        @error "the basis should be evaluated at each θ"
-    end
-
-return BoundaryBasis{BC,T}(boundarytype,θs,basis,fourier_modes)
+    basis::Vector{BD} = BoundaryData[]
+) where {BC <: BoundaryCondition,BD<:BoundaryData}
+    return BoundaryBasis{BC,BD}(boundarytype, basis)
 end
 
 struct BearingSimulation{BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, T}

--- a/src/bearing.jl
+++ b/src/bearing.jl
@@ -128,7 +128,7 @@ struct BearingSimulation{BC1 <: BoundaryCondition, BC2 <: BoundaryCondition, T}
     boundarybasis::BoundaryBasis{BC1,T}
     tol::T
 
-    function BearingSimulation(ω::T, bearing::RollerBearing{T}, boundarydata1::BoundaryData{BC1,T}, boundarydata2::BoundaryData{BC2,T},boundarybasis::BoundaryBasis{BC1,T}=BoundaryBasis{typeof(boundarydata1.boundarytype),typeof(bearing.medium.cp)}[]; tol::T = eps(T)^(1/2), basis_order::Int = -1) where {T, BC1 <: BoundaryCondition, BC2 <: BoundaryCondition}
+    function BearingSimulation(ω::T, bearing::RollerBearing{T}, boundarydata1::BoundaryData{BC1,T}, boundarydata2::BoundaryData{BC2,T}; tol::T = eps(T)^(1/2), basis_order::Int = -1, boundarybasis::BoundaryBasis{BC1,T} = BoundaryBasis(boundarydata1.boundarytype)) where {T, BC1 <: BoundaryCondition, BC2 <: BoundaryCondition}
 
         if size(boundarydata1.fourier_modes,1) != size(boundarydata2.fourier_modes,1)
             @error "number of fourier_modes in boundarydata1 and boundarydata2 needs to be the same"

--- a/src/cylindrical/boundary_conditions.jl
+++ b/src/cylindrical/boundary_conditions.jl
@@ -67,11 +67,13 @@ function ElasticWave(sim::BearingSimulation)
             ]
 
             B = reshape(basisfouriermodes[m+basis_order+1,:], 2, number_of_parameters)
-            B = vcat(B, zeros(ComplexF64, 2, number_of_parameters))
+            
             if boundarybasis.boundarytype.inner    
                 M = boundarycondition_system(ω, bearing, boundarybasis.boundarytype, TractionBoundary(outer = true), m)
+                B = vcat(B, zeros(ComplexF64, 2, number_of_parameters))
             else
                 M = boundarycondition_system(ω, bearing, TractionBoundary(inner = true), boundarybasis.boundarytype, m)
+                B = vcat(zeros(ComplexF64, 2, number_of_parameters), B)
             end
             prior = M \ B
 

--- a/src/cylindrical/boundary_conditions.jl
+++ b/src/cylindrical/boundary_conditions.jl
@@ -68,7 +68,11 @@ function ElasticWave(sim::BearingSimulation)
 
             B = reshape(basisfouriermodes[m+basis_order+1,:], 2, number_of_parameters)
             B = vcat(B, zeros(ComplexF64, 2, number_of_parameters))
-            M = boundarycondition_system(ω, bearing, TractionBoundary(inner = true), TractionBoundary(outer = true), m)
+            if boundarybasis.boundarytype.inner    
+                M = boundarycondition_system(ω, bearing, boundarybasis.boundarytype, TractionBoundary(outer = true), m)
+            else
+                M = boundarycondition_system(ω, bearing, TractionBoundary(inner = true), boundarybasis.boundarytype, m)
+            end
             prior = M \ B
 
             x = (A*prior) \ b

--- a/src/cylindrical/boundary_conditions.jl
+++ b/src/cylindrical/boundary_conditions.jl
@@ -20,6 +20,7 @@ function ElasticWave(sim::BearingSimulation)
     ω = sim.ω
     bearing = sim.bearing
 
+    basis = sim.boundarybasis
     T = typeof(ω)
 
     kP = ω / bearing.medium.cp;

--- a/src/cylindrical/boundary_conditions.jl
+++ b/src/cylindrical/boundary_conditions.jl
@@ -25,8 +25,7 @@ function ElasticWave(sim::BearingSimulation)
     basisfouriermodes = [b.fourier_modes for b in boundarybasis.basis]
     basisfouriermodes = hcat(basisfouriermodes...) |> collect
 
-    number_of_parameters = convert(Int,size(basisfouriermodes,2)/2)
-
+    number_of_parameters = length(boundarybasis.basis)
     T = typeof(ω)
 
     kP = ω / bearing.medium.cp;
@@ -60,28 +59,31 @@ function ElasticWave(sim::BearingSimulation)
         end
     
     else
-        A = boundarycondition_system(ω, bearing, sim.boundarydata1.boundarytype, sim.boundarydata2.boundarytype, m)
-        b = [
-            sim.boundarydata1.fourier_modes[m+basis_order+1,:];
-            sim.boundarydata2.fourier_modes[m+basis_order+1,:]
-        ]
+        for m in -basis_order:basis_order
+            A = boundarycondition_system(ω, bearing, sim.boundarydata1.boundarytype, sim.boundarydata2.boundarytype, m)
+            b = [
+                sim.boundarydata1.fourier_modes[m+basis_order+1,:];
+                sim.boundarydata2.fourier_modes[m+basis_order+1,:]
+            ]
 
-        B = reshape(basisfouriermodes[m+basis_order+1,:], 2, number_of_parameters)
-        B = vcat(B, zeros(ComplexF64, 2, number_of_parameters))
-        M = boundarycondition_system(ω, bearing, TractionBoundary(inner = true), TractionBoundary(outer = true), m)
-        prior = M \ B
+            B = reshape(basisfouriermodes[m+basis_order+1,:], 2, number_of_parameters)
+            B = vcat(B, zeros(ComplexF64, 2, number_of_parameters))
+            M = boundarycondition_system(ω, bearing, TractionBoundary(inner = true), TractionBoundary(outer = true), m)
+            prior = M \ B
 
-        x = (A*prior) \ B
+            x = (A*prior) \ b
 
-        a = prior * x
+            a = prior * x
+            
 
-        relative_error = norm(A*a - b) / norm(b)
-        if relative_error > sim.tol
-            @warn "The relative error for the boundary conditions was $(relative_error) for (ω,basis_order) = $((ω,m))"
+            relative_error = norm(A*a - b) / norm(b)
+            if relative_error > sim.tol
+                @warn "The relative error for the boundary conditions was $(relative_error) for (ω,basis_order) = $((ω,m))"
+            end
+
+            coefficients[m + basis_order + 1] = a
+            mode_errors[m + basis_order + 1] = relative_error
         end
-
-        coefficients[m + basis_order + 1] = a
-        mode_errors[m + basis_order + 1] = relative_error
     end
     coefficients = transpose(hcat(coefficients...)) |> collect
 


### PR DESCRIPTION
add BoundaryBasis to bearing.jl
BearingSimulation calculates fourier_modes of BoundaryBasis automatically.
Mode-by-mode implementation of BoundaryBasis into ElasticWave in /cylindrical/boundary_conditions.jl 